### PR TITLE
Use `never` to typecheck enum variants

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -2,7 +2,6 @@ import type { Bit } from '@imretro/bitio';
 import type { Color } from '@imretro/color';
 import { Grayscale, RGB, RGBA } from '@imretro/color';
 import { Reader as BitReader } from '@imretro/bitio';
-import { unreachable } from 'logic-branch-helpers';
 import type { Palette } from './palette';
 import * as palettes from './palette';
 import { DecodeError } from './errors';
@@ -101,8 +100,10 @@ export default class Image {
         bitsPerChannel = 8;
         break;
       /* c8 ignore start */
-      default:
-        return unreachable();
+      default: {
+        const _: never = accuracy;
+        return _;
+      }
       /* c8 ignore end */
     }
 
@@ -118,8 +119,10 @@ export default class Image {
           case 8:
             break;
           /* c8 ignore start */
-          default:
-            return unreachable();
+          default: {
+            const _: never = bitsPerChannel;
+            return _;
+          }
           /* c8 ignore end */
         }
         colorChannels.push(channel);
@@ -136,8 +139,10 @@ export default class Image {
           colors.push(new RGBA(...(colorChannels as RGBATuple)));
           break;
         /* c8 ignore start */
-        default:
-          return unreachable();
+        default: {
+          const _: never = channels;
+          return _;
+        }
         /* c8 ignore end */
       }
     }
@@ -152,8 +157,10 @@ export default class Image {
       case flags.PixelMode.EightBit:
         return new palettes.EightBit(colors);
       /* c8 ignore start */
-      default:
-        return unreachable(`Pixel mode ${pixelMode}`);
+      default: {
+        const _: never = pixelMode;
+        return _;
+      }
       /* c8 ignore end */
     }
   }
@@ -167,8 +174,10 @@ export default class Image {
       case flags.PixelMode.EightBit:
         return palettes.default8Bit;
       /* c8 ignore start */
-      default:
-        return unreachable(`Pixel mode ${pixelMode}`);
+      default: {
+        const _: never = pixelMode;
+        return _;
+      }
       /* c8 ignore end */
     }
   }
@@ -194,8 +203,10 @@ export default class Image {
         bitsPerPixel = 8;
         break;
       /* c8 ignore start */
-      default:
-        return unreachable();
+      default: {
+        const _: never = pixelMode;
+        return _;
+      }
       /* c8 ignore end */
     }
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -101,8 +101,8 @@ export default class Image {
         break;
       /* c8 ignore start */
       default: {
-        const _: never = accuracy;
-        return _;
+        const unused: never = accuracy;
+        return unused;
       }
       /* c8 ignore end */
     }
@@ -120,8 +120,8 @@ export default class Image {
             break;
           /* c8 ignore start */
           default: {
-            const _: never = bitsPerChannel;
-            return _;
+            const unused: never = bitsPerChannel;
+            return unused;
           }
           /* c8 ignore end */
         }
@@ -140,8 +140,8 @@ export default class Image {
           break;
         /* c8 ignore start */
         default: {
-          const _: never = channels;
-          return _;
+          const unused: never = channels;
+          return unused;
         }
         /* c8 ignore end */
       }
@@ -158,8 +158,8 @@ export default class Image {
         return new palettes.EightBit(colors);
       /* c8 ignore start */
       default: {
-        const _: never = pixelMode;
-        return _;
+        const unused: never = pixelMode;
+        return unused;
       }
       /* c8 ignore end */
     }
@@ -175,8 +175,8 @@ export default class Image {
         return palettes.default8Bit;
       /* c8 ignore start */
       default: {
-        const _: never = pixelMode;
-        return _;
+        const unused: never = pixelMode;
+        return unused;
       }
       /* c8 ignore end */
     }
@@ -204,8 +204,8 @@ export default class Image {
         break;
       /* c8 ignore start */
       default: {
-        const _: never = pixelMode;
-        return _;
+        const unused: never = pixelMode;
+        return unused;
       }
       /* c8 ignore end */
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,7 @@ export type ChannelCount = 1 | 3 | 4;
 /**
  * @ignore
  */
-export const pixelModeToColors = (mode: PixelMode): ColorCount => {
+export const pixelModeToColors = (mode: PixelMode & number): ColorCount => {
   switch (mode) {
     case PixelMode.OneBit:
       return 2;
@@ -26,7 +26,7 @@ export const pixelModeToColors = (mode: PixelMode): ColorCount => {
 /**
  * @ignore
  */
-export const colorsToPixelMode = (colors: ColorCount): PixelMode => {
+export const colorsToPixelMode = (colors: ColorCount & number): PixelMode => {
   switch (colors) {
     case 2:
       return PixelMode.OneBit;
@@ -46,7 +46,7 @@ export const colorsToPixelMode = (colors: ColorCount): PixelMode => {
 /**
  * @ignore
  */
-export const channelToCount = (channels: ColorChannels): ChannelCount => {
+export const channelToCount = (channels: ColorChannels & number): ChannelCount => {
   switch (channels) {
     case ColorChannels.Grayscale:
       return 1;

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,8 +16,8 @@ export const pixelModeToColors = (mode: PixelMode): ColorCount => {
       return 256;
     /* c8 ignore start */
     default: {
-      const _: never = mode;
-      return _;
+      const unused: never = mode;
+      return unused;
     }
     /* c8 ignore end */
   }
@@ -36,8 +36,8 @@ export const colorsToPixelMode = (colors: ColorCount): PixelMode => {
       return PixelMode.EightBit;
     /* c8 ignore start */
     default: {
-      const _: never = colors;
-      return _;
+      const unused: never = colors;
+      return unused;
     }
     /* c8 ignore end */
   }
@@ -56,8 +56,8 @@ export const channelToCount = (channels: ColorChannels): ChannelCount => {
       return 4;
     /* c8 ignore start */
     default: {
-      const _: never = channels;
-      return _;
+      const unused: never = channels;
+      return unused;
     }
     /* c8 ignore end */
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import { unreachable } from 'logic-branch-helpers';
 import { PixelMode, ColorChannels } from './flags';
 
 export type ColorCount = 2 | 4 | 256;
@@ -16,8 +15,10 @@ export const pixelModeToColors = (mode: PixelMode): ColorCount => {
     case PixelMode.EightBit:
       return 256;
     /* c8 ignore start */
-    default:
-      return unreachable();
+    default: {
+      const _: never = mode;
+      return _;
+    }
     /* c8 ignore end */
   }
 };
@@ -34,8 +35,10 @@ export const colorsToPixelMode = (colors: ColorCount): PixelMode => {
     case 256:
       return PixelMode.EightBit;
     /* c8 ignore start */
-    default:
-      return unreachable();
+    default: {
+      const _: never = colors;
+      return _;
+    }
     /* c8 ignore end */
   }
 };
@@ -52,8 +55,10 @@ export const channelToCount = (channels: ColorChannels): ChannelCount => {
     case ColorChannels.RGBA:
       return 4;
     /* c8 ignore start */
-    default:
-      return unreachable();
+    default: {
+      const _: never = channels;
+      return _;
+    }
     /* c8 ignore end */
   }
 };


### PR DESCRIPTION
Asserts that all enum variants have been tested by asserting that the remaining type after cases is `never`.